### PR TITLE
Fix build and fix configuration files syntax

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,10 +87,10 @@ dependencies {
   // DB dependencies.
   // You can choose one of them.
   // HSQLDB
-//  compile "org.hsqldb:hsqldb:hsqldb_version"
+//  compile "org.hsqldb:hsqldb:$hsqldb_version"
 
   // Mysql
-//  compile "mysql:mysql-connector-java:mysql_version"
+//  compile "mysql:mysql-connector-java:$mysql_version"
 
   // Postgres
   compile "org.postgresql:postgresql:$postgresql_version"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/saintdan/framework/tools/RemoteAddressUtils.java
+++ b/src/main/java/com/saintdan/framework/tools/RemoteAddressUtils.java
@@ -1,6 +1,5 @@
 package com.saintdan.framework.tools;
 
-import com.saintdan.framework.servlet.RequestWrapper;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
 
@@ -12,23 +11,6 @@ import org.apache.commons.lang3.StringUtils;
 public class RemoteAddressUtils {
 
   public static String getRealIp(HttpServletRequest request) {
-    String ip = request.getHeader("X-Forwarded-For");
-    if (StringUtils.isNotEmpty(ip) && !"unKnown".equalsIgnoreCase(ip)) {
-      int index = ip.indexOf(",");
-      if (index != -1) {
-        return ip.substring(0, index);
-      } else {
-        return ip;
-      }
-    }
-    ip = request.getHeader("X-Real-IP");
-    if (StringUtils.isNotEmpty(ip) && !"unKnown".equalsIgnoreCase(ip)) {
-      return ip;
-    }
-    return request.getRemoteAddr();
-  }
-
-  public static String getRealIp(RequestWrapper request) {
     String ip = request.getHeader("X-Forwarded-For");
     if (StringUtils.isNotEmpty(ip) && !"unKnown".equalsIgnoreCase(ip)) {
       int index = ip.indexOf(",");


### PR DESCRIPTION
Current invocation of `./gradlew clean build bootRun` results with an error message: 

`Spring Boot plugin requires Gradle 4.4 or later. The current version is Gradle 4.3`

![screenshot 2019-01-12 at 04 13 09](https://user-images.githubusercontent.com/1548104/51068587-632a6c80-1620-11e9-8045-8396dd613acf.png)